### PR TITLE
Update nys-its references to new ny organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The Universal Navigation is part of New York State’s planned progress toward c
 #### Interactive Banner Option
 
 - [Instructions and embed code] (notes/interactive-option.md)
-- [Demo](http://nys-its.github.io/universal-navigation/demos/interactive-option-demo.html)
-- [DEV Environment Demo](http://nys-its.github.io/universal-navigation/demos/interactive-option-demo-DEV.html)
+- [Demo](http://ny.github.io/universal-navigation/demos/interactive-option-demo.html)
+- [DEV Environment Demo](http://ny.github.io/universal-navigation/demos/interactive-option-demo-DEV.html)
 #### Static Banner Option
 
 - [Instructions and embed code] (notes/static-option.md)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The Universal Navigation is part of New York State’s planned progress toward c
 #### Static Banner Option
 
 - [Instructions and embed code] (notes/static-option.md)
-- [Demo](http://nys-its.github.io/universal-navigation/demos/static-option-demo.html)
-- [DEV Environment Demo](http://nys-its.github.io/universal-navigation/demos/static-option-demo-DEV.html)
+- [Demo](http://ny.github.io/universal-navigation/demos/static-option-demo.html)
+- [DEV Environment Demo](http://ny.github.io/universal-navigation/demos/static-option-demo-DEV.html)
 
 ## Universal Footer (required)
 
@@ -41,4 +41,4 @@ The Universal Navigation is part of New York State’s planned progress toward c
 - If necessary, questions can be emailed to innovate@its.ny.gov
 
 ### QA Admin
-- Checklist for each release/update testing cycle is located [here](https://github.com/nys-its/universal-navigation/blob/gh-pages/notes/QA-Process-Checklist.md#qa-checklist)
+- Checklist for each release/update testing cycle is located [here](https://github.com/ny/universal-navigation/blob/gh-pages/notes/QA-Process-Checklist.md#qa-checklist)

--- a/contributing.md
+++ b/contributing.md
@@ -64,7 +64,7 @@
       - moderate: only impacts subset of users
 
 ### Reference
-- See other optional labels at https://github.com/nys-its/universal-navigation/labels
+- See other optional labels at https://github.com/ny/universal-navigation/labels
 
 ### Filters
 - Issues with no milestone http://git.io/wVmSBw

--- a/demos/yammer-announcement.md
+++ b/demos/yammer-announcement.md
@@ -1,7 +1,7 @@
 The Universal Navigation embed code is now in BETA, and available via Github from the following link: 
 
-https://github.com/nys-its/universal-navigation
+https://github.com/ny/universal-navigation
 
 Please check the README.md file (visible below files) for new information. Given the timeframe, we will be updating the FAQ and code in real time. 
 
-We encourage you to post general questions on Yammer, and please check the main spreadsheet for questions from the ALPHA period. Feedback will be added to the sheet as needed. Links for questions and feedback are listed under "BETA Comment Period" here: https://github.com/nys-its/universal-navigation#beta-comment-period
+We encourage you to post general questions on Yammer, and please check the main spreadsheet for questions from the ALPHA period. Feedback will be added to the sheet as needed. Links for questions and feedback are listed under "BETA Comment Period" here: https://github.com/ny/universal-navigation#beta-comment-period

--- a/notes/QA-Process-Checklist.md
+++ b/notes/QA-Process-Checklist.md
@@ -5,15 +5,15 @@ Whenever an update to the universal navigation is released, copy and paste the f
 
 ```
 - [ ]  If embed code has been updated 
-  - [ ] Update embed code on GitHub at https://github.com/nys-its/universal-navigation/blob/gh-pages/notes/testing-against-development-staging.md 
-    - [ ] Interactive version https://github.com/nys-its/universal-navigation/blob/gh-pages/notes/interactive-option.md  
-    - [ ] Static version https://github.com/nys-its/universal-navigation/blob/gh-pages/notes/static-option.md  
-    - [ ] Footer https://github.com/nys-its/universal-navigation/blob/gh-pages/notes/footer.md 
+  - [ ] Update embed code on GitHub at https://github.com/ny/universal-navigation/blob/gh-pages/notes/testing-against-development-staging.md 
+    - [ ] Interactive version https://github.com/ny/universal-navigation/blob/gh-pages/notes/interactive-option.md  
+    - [ ] Static version https://github.com/ny/universal-navigation/blob/gh-pages/notes/static-option.md  
+    - [ ] Footer https://github.com/ny/universal-navigation/blob/gh-pages/notes/footer.md 
 - [ ] Update demo pages with new embed code
-  - [ ] [Interactive Demo](https://github.com/nys-its/universal-navigation/blob/gh-pages/demos/interactive-option-demo.html)
-  - [ ] [Interactive Demo DEV](https://github.com/nys-its/universal-navigation/blob/gh-pages/demos/interactive-option-demo-DEV.html)
-  - [ ] [Static Demo](https://github.com/nys-its/universal-navigation/blob/gh-pages/demos/static-option-demo.html)
-  - [ ] [Static DEV Demo](https://github.com/nys-its/universal-navigation/blob/gh-pages/demos/static-option-demo-DEV.html)
+  - [ ] [Interactive Demo](https://github.com/ny/universal-navigation/blob/gh-pages/demos/interactive-option-demo.html)
+  - [ ] [Interactive Demo DEV](https://github.com/ny/universal-navigation/blob/gh-pages/demos/interactive-option-demo-DEV.html)
+  - [ ] [Static Demo](https://github.com/ny/universal-navigation/blob/gh-pages/demos/static-option-demo.html)
+  - [ ] [Static DEV Demo](https://github.com/ny/universal-navigation/blob/gh-pages/demos/static-option-demo-DEV.html)
 - [ ] Create GitHub milestone for issue tracking for new test cycle 
 - [ ] Send out announcements 
   - [ ] Yammer Announcement to uNav group 

--- a/notes/faqs.md
+++ b/notes/faqs.md
@@ -53,9 +53,9 @@ When presented with a bug in uNav, follow the appropriate steps to determine the
 
 ##### If you problem is "Globally scoped":
 
- 1. [Search GitHub for any issues that may be the same or similar to your own](https://github.com/nys-its/universal-navigation/issues)
+ 1. [Search GitHub for any issues that may be the same or similar to your own](https://github.com/ny/universal-navigation/issues)
   * If you find an issue, read all the comments and determine if you need to add more info from your instance or not.
- 1. If you can't find any related issues, [open a new issue on GitHub](https://github.com/nys-its/universal-navigation/issues/new)
+ 1. If you can't find any related issues, [open a new issue on GitHub](https://github.com/ny/universal-navigation/issues/new)
   * Be sure to include all the information required for an issue, outlined in [the contribution guidelines document](/contributing.md#when-creating-an-issue-please-provide-all-possible-of-the-following).
 
 #### If your problem is "Instance scoped":
@@ -66,7 +66,7 @@ When presented with a bug in uNav, follow the appropriate steps to determine the
 
 ### How will issues be tracked after launch?
 
-[GitHub Issues](https://github.com/nys-its/universal-navigation/issues) in this repo will be used to track feedback, issues, and enhancement requests after the Universal Navigation is released.
+[GitHub Issues](https://github.com/ny/universal-navigation/issues) in this repo will be used to track feedback, issues, and enhancement requests after the Universal Navigation is released.
 
 ### How will the Universal Navigation search field work with our local search?
 
@@ -94,7 +94,7 @@ The unniversal navigation was designed to take up the entire width of the webpag
 
 ### When can the Universal Navigaton be placed in containers, `<div>` tags, or other locations away from the `<body>` tag?
 
-As specified in the [implementation instructions](https://github.com/nys-its/universal-navigation/blob/gh-pages/notes/interactive-option.md), the code for the universal navigation should be placed as close as possible to the `<body>` tag without being inside a respective div or container.
+As specified in the [implementation instructions](https://github.com/ny/universal-navigation/blob/gh-pages/notes/interactive-option.md), the code for the universal navigation should be placed as close as possible to the `<body>` tag without being inside a respective div or container.
 
 In specific instances where the code needs to be placed in a container to resolve site issues (such as a styling/CSS issue), testing should be done to make sure that the universal navigation remains usable across all functions.
 
@@ -112,7 +112,7 @@ No, only one would be active at a time.
 
 A simple demo is available at the link below. The demo points to the development server to display a test alert.
 
-[Universal Navigation Alerts - Development Environment Test](http://nys-its.github.io/universal-navigation/demos/static-option-demo-DEV.html)
+[Universal Navigation Alerts - Development Environment Test](http://ny.github.io/universal-navigation/demos/static-option-demo-DEV.html)
 
 ### How do I update my code to add the alerts?
 
@@ -120,6 +120,6 @@ If you're using the **Interactive Banner**, you don't have to do anything.
 
 If you're using the **Static Banner**, you can follow these directions to add a special HTML file that will enable the alerts. We recommmend testing in a development environment first before deploying to production.
 
-[Instructions for adding Universal Navigation Alerts](https://github.com/nys-its/universal-navigation/blob/gh-pages/notes/static-option.md#inserting-functionality-for-emergency-and-news-alerts)
+[Instructions for adding Universal Navigation Alerts](https://github.com/ny/universal-navigation/blob/gh-pages/notes/static-option.md#inserting-functionality-for-emergency-and-news-alerts)
 
-[Additional information on QA Testing](https://github.com/nys-its/universal-navigation/blob/gh-pages/notes/testing-against-development-staging.md)
+[Additional information on QA Testing](https://github.com/ny/universal-navigation/blob/gh-pages/notes/testing-against-development-staging.md)

--- a/notes/steps-for-testing.md
+++ b/notes/steps-for-testing.md
@@ -3,11 +3,11 @@
   - page should be on the development side, and not reside on anything public facing. 
  
 ### Insert updated development embed code in a test page 
-  - https://github.com/nys-its/universal-navigation/blob/gh-pages/notes/testing-against-development-staging.md 
+  - https://github.com/ny/universal-navigation/blob/gh-pages/notes/testing-against-development-staging.md 
  
 ### Testing 
   - Testing should be completed within 2 business days of the embed code being updated in dev. 
-  - Example unit tests can be found here https://github.com/nys-its/universal-navigation/blob/gh-pages/notes/what-to-test.md 
+  - Example unit tests can be found here https://github.com/ny/universal-navigation/blob/gh-pages/notes/what-to-test.md 
   - Try to focus on the functionality provided by the navigation.  This can include clickable links, and the styling presented within the navigation. 
  
 ###  Issues 


### PR DESCRIPTION
Replaced references to nys-its.github to ny.github across all files.