### PR TITLE
Add doctype and charset to xd_nygov

### DIFF
--- a/notes/xd_nygov.html
+++ b/notes/xd_nygov.html
@@ -1,9 +1,9 @@
+<!DOCTYPE html>
 <html>
 <head>
+    <meta charset="utf-8">
     <title>NY</title>
-    <meta name="description" content="NY Universal Navigation helper file." 
-        data-version="1.1.3.0" 
-    />
+    <meta name="description" content="NY Universal Navigation helper file." data-version="1.1.3.0">
 </head>
 <body>
     <script>


### PR DESCRIPTION
It's probably safer to include these. Also, I made the `<meta description>` tag all one line because I'm not sure how well older browsers would handle the line breaks.